### PR TITLE
feat: Add postgres MCP server

### DIFF
--- a/mcp-server32/mcp-server32/README.md
+++ b/mcp-server32/mcp-server32/README.md
@@ -1,0 +1,316 @@
+# PostgreSQL MCP Server
+
+A Model Context Protocol (MCP) server for PostgreSQL that provides secure database connectivity with built-in SQL injection protection and read-only connection options.
+
+> [!NOTE]  
+> This MCP server uses pg8000, a pure Python PostgreSQL driver for connecting to a postgres database (e.g., hosted in AWS RDS). If you are using AWS *Aurora* PostgreSQL, consider leveraging the data api and using the open source [Aurora Postgres MCP Server by AWS](https://github.com/awslabs/mcp/tree/main/src/postgres-mcp-server) instead. You can extend the AWS provided MCP server with the tools provided by this inner source MCP server to get the best from both worlds.
+
+- [PostgreSQL MCP Server](#postgresql-mcp-server)
+  - [Features](#features)
+  - [Prerequisites](#prerequisites)
+  - [Configuration](#configuration)
+    - [Environment Variables](#environment-variables)
+      - [Option 1: AWS Secrets Manager (Recommended)](#option-1-aws-secrets-manager-recommended)
+      - [Option 2: Direct Environment Variables](#option-2-direct-environment-variables)
+      - [Optional Configuration](#optional-configuration)
+  - [Usage](#usage)
+    - [Running Locally](#running-locally)
+    - [Deployment via ML Service](#deployment-via-ml-service)
+  - [MCP Resources](#mcp-resources)
+    - [Available Resources](#available-resources)
+    - [MCP Tools](#mcp-tools)
+    - [Example Tool Usage](#example-tool-usage)
+  - [MCP Tools](#mcp-tools-1)
+    - [execute\_sql](#execute_sql)
+    - [get\_tables](#get_tables)
+    - [get\_table\_schemas](#get_table_schemas)
+  - [Security Features](#security-features)
+    - [SQL Injection Protection](#sql-injection-protection)
+    - [Read-Only Mode](#read-only-mode)
+    - [Detected Mutating Keywords](#detected-mutating-keywords)
+  - [Database Schema Support](#database-schema-support)
+  - [PostgreSQL-Specific Features](#postgresql-specific-features)
+  - [Testing](#testing)
+  - [Development](#development)
+    - [Project Structure](#project-structure)
+  - [Contributing](#contributing)
+
+
+## Features
+
+- **Database Access**: Built-in SQL injection detection and prevention
+- **Read-Only Mode**: Configurable read-only connection to prevent accidental data modification
+- **AWS Integration**: Supports AWS Secrets Manager for secure credential management
+- **ML Service & Lambda Ready**: Optimized for AWS Lambda deployment using the [ML Service serverless MCP terraform module](https://github.com/bayer-int/ph-ds-ml-serverless-api-mcp)
+- **Schema Discovery**: Automatic table and column schema detection with descriptions
+- **Resource-Based API**: MCP resources for tables, schemas, and data exploration (can be easily switched to model-controlled tools)
+
+## Prerequisites
+
+- Python 3.12+
+- `uv` package manager (for local development & deployment)
+- PostgreSQL database
+- pg8000 PostgreSQL driver (pure Python driver)
+- AWS credentials and AWS CLI (if using Secrets Manager)
+
+## Configuration
+
+1. Make sure prerequisites are installed.
+2. Configure environment variables.
+
+### Environment Variables
+
+The server supports two configuration methods:
+
+#### Option 1: AWS Secrets Manager (Recommended)
+
+Either use a .env file or set environment variables directly.
+```bash
+SECRET_ID=your-secret-id  # AWS Secrets Manager secret ID
+```
+
+The secret should contain:
+```json
+{
+  "host": "your-postgresql-host",
+  "port": 5432,
+  "username": "your-username", 
+  "password": "your-password",
+  "dbname": "your-database-name"
+}
+```
+
+#### Option 2: Direct Environment Variables
+```bash
+PG_HOST=your-postgresql-host
+PG_PORT=5432  # Optional, defaults to 5432
+PG_USER=your-username
+PG_PASSWORD=your-password
+PG_DBNAME=your-database-name
+```
+
+#### Optional Configuration
+```bash
+READ_ONLY_CONNECTION=true    # Default: true - prevents mutating queries
+DEBUG=false                  # Default: false - enables debug logging
+```
+
+## Usage
+
+### Running Locally
+
+```bash
+cd postgres/src
+# Run the MCP server directly (packages will be installed on-the-fly)
+uv run main.py
+```
+
+### Deployment via ML Service 
+
+The server is designed to run on AWS Lambda using Mangum in stateless mode. You can use the exemplary configuration of the ML Service serverless MCP terraform module in the [/terraform](./terraform/) folder as starting point. 
+
+## MCP Resources
+
+The server exposes several MCP resources for database exploration:
+
+### Available Resources
+
+- `postgresql://{table_name}/data` - Get sample data from a table (limited to 100 rows by default)
+
+### MCP Tools
+
+The server provides several tools for database interaction:
+
+- `execute_sql` - Execute SQL queries with built-in security checks  
+- `get_tables` - List PostgreSQL tables and (materialized) views with descriptions from a specific schema
+- `get_table_schemas` - Get detailed schema information for tables including column details and foreign key relationships
+
+### Example Tool Usage
+
+```python
+import asyncio
+import pprint
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+async def example():
+    shttp = StreamableHttpTransport(
+        # The URL of the server
+        url="http://127.0.0.1:8000/mcp",
+        headers={
+            # leave empty if no authentication is needed
+            # "Authorization": "Bearer "  # or
+            # "Authorization": "API KEY"
+        },
+    )
+
+    async with Client(transport=shttp) as client:
+        # List available tools
+        tools = await client.list_tools()
+        pprint.pp(f"Available tools: {tools}")
+
+        # Get tables from public schema
+        tables = await client.call_tool("get_tables", {"schema_name": "public"})
+        pprint.pp(f"Tables: {tables}")
+        
+        # Get schema for specific tables
+        if tables:
+            table_names = [table['name'] for table in tables[0].text if isinstance(tables[0].text, list)]
+            schemas = await client.call_tool("get_table_schemas", {
+                "tables": table_names[:3],  # Get schema for first 3 tables
+                "schema_name": "public"
+            })
+            pprint.pp(f"Table schemas: {schemas}")
+
+        # Execute a sample query
+        result = await client.call_tool(
+            "execute_sql",
+            {"query": "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' LIMIT 5"},
+        )
+        pprint.pp(result[0].text)
+
+        # Get sample data from a table (using resource)
+        data = await client.read_resource("postgresql://your_table_name/data")
+        pprint.pp(data)
+
+
+
+if __name__ == "__main__":
+    asyncio.run(example())
+```
+
+## MCP Tools
+
+### execute_sql
+
+Execute SQL queries with built-in security checks.
+
+**Parameters:**
+- `query` (string): SQL query to execute
+
+**Security Features:**
+- SQL injection pattern detection
+- Read-only mode enforcement (blocks INSERT, UPDATE, DELETE, etc.)
+- Suspicious pattern filtering
+
+**Returns:**
+- For SELECT queries: CSV-formatted results with column headers
+- For non-SELECT queries: Success message with affected row count
+
+### get_tables
+
+List PostgreSQL tables and views with their descriptions from a specific schema.
+
+**Parameters:**
+- `schema_name` (string, optional): Schema name (defaults to "public")
+
+**Returns:**
+- List of dictionaries containing table information:
+  - `name`: Table name
+  - `type`: Table type (BASE TABLE, VIEW, MATERIALIZED VIEW)
+  - `description`: Table description from PostgreSQL comments
+
+### get_table_schemas
+
+Get detailed schema information for tables including column details and foreign key relationships.
+
+**Parameters:**
+- `tables` (list[str]): Names of the tables to get schema information for
+- `schema_name` (string, optional): Schema name (defaults to "public")
+
+**Returns:**
+- List of dictionaries containing detailed table schema:
+  - `name`: Table name
+  - `schema`: Schema name
+  - `description`: Table description
+  - `columns`: List of column information including:
+    - `name`: Column name
+    - `type`: Data type
+    - `max_length`: Maximum character length (for text types)
+    - `nullable`: Whether column allows NULL values
+    - `default`: Default value
+    - `description`: Column description from PostgreSQL comments
+    - `foreign_key`: Foreign key relationship information (if applicable)
+
+## Security Features
+
+### SQL Injection Protection
+
+The server includes comprehensive SQL injection protection:
+
+- **Pattern Detection**: Identifies suspicious patterns like SQL comments, UNION injections, and tautologies
+- **Keyword Filtering**: Blocks dangerous functions and PostgreSQL-specific risky patterns
+- **Input Validation**: Validates query structure and content
+
+### Read-Only Mode
+
+When `READ_ONLY_CONNECTION=true` (default), the server blocks:
+- INSERT, UPDATE, DELETE operations
+- DDL operations (CREATE, DROP, ALTER)
+- Administrative commands and functions
+- Permission changes (GRANT, REVOKE)
+- PostgreSQL extensions and function creation
+
+### Detected Mutating Keywords
+
+```
+INSERT, UPDATE, DELETE, MERGE, TRUNCATE,
+CREATE, DROP, ALTER, RENAME, GRANT, REVOKE,
+COMMENT ON, SECURITY LABEL, CREATE EXTENSION, CREATE FUNCTION,
+INSTALL, CLUSTER, REINDEX, VACUUM, ANALYZE
+```
+
+## Database Schema Support
+
+The server automatically discovers and exposes:
+
+- **Table Names**: From `information_schema.tables`
+- **Column Information**: Data types, nullable status, defaults, character limits
+- **Descriptions**: Table and column descriptions from PostgreSQL comments (`pg_description`)
+- **Schema Organization**: Support for multiple database schemas (default: "public")
+- **Foreign Key Relationships**: Automatic detection of foreign key constraints
+- **View and Materialized View Support**: Includes regular views and materialized views
+
+## PostgreSQL-Specific Features
+
+The server supports PostgreSQL-specific features and capabilities:
+
+- **Schema Support**: Works with any PostgreSQL schema (defaults to "public")
+- **Views and Materialized Views**: Full support for both regular and materialized views
+- **Extended Properties**: Reads table and column descriptions from PostgreSQL comment system
+- **Foreign Key Detection**: Automatically discovers foreign key relationships
+- **SSL Support**: Built-in SSL/TLS support for secure connections
+
+## Testing
+
+Run the test suite:
+
+```bash
+cd postgres/src
+pytest .
+```
+
+## Development
+
+### Project Structure
+
+```
+postgres/
+├── src/
+│   ├── main.py          # (Lambda) entry point
+│   ├── v1/
+│   │   └── server.py    # MCP server implementation
+│   ├── mlservice/
+│   │   ├── db.py        # Database connection and security
+│   │   └── utils.py     # AWS utilities
+│   └── tests/
+│       ├── test_db.py   # Database tests
+│       └── test_utils.py # Utility tests
+├── terraform/           # ML Service module Terraform config 
+├── README.md            # This file
+```
+
+## Contributing
+
+Please refer to the main repository's `CONTRIBUTING.md` and `DEVELOPER_GUIDE.md` for contribution guidelines.

--- a/mcp-server32/mcp-server32/src/client.py
+++ b/mcp-server32/mcp-server32/src/client.py
@@ -1,0 +1,36 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "certifi",
+#     "fastmcp",
+# ]
+# ///
+import asyncio
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+
+async def example():
+    shttp = StreamableHttpTransport(
+        # The URL of the server
+        url="http://localhost:8000/mcp",
+        headers={
+            # leave empty if no authentication is needed
+            # "Authorization": "Bearer <YOUR TOKEN HERE>"  # or
+            # "Authorization": "<YOUR API KEY HERE>"
+        },
+    )
+
+    async with Client(transport=shttp) as client:
+        tools = await client.list_tools()
+        print(f"Available tools: {tools}")
+
+        result = await client.call_tool(
+            "execute_sql", {"query": "SELECT * FROM my_table WHERE id = 5"}
+        )
+        print(f"Result: {result.data}")
+
+
+if __name__ == "__main__":
+    asyncio.run(example())

--- a/mcp-server32/mcp-server32/src/main.py
+++ b/mcp-server32/mcp-server32/src/main.py
@@ -1,0 +1,43 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "aws-lambda-powertools",
+#     "boto3",
+#     "dotenv",
+#     "fastmcp",
+#     "mangum",
+#     "pg8000",
+# ]
+# ///
+"""Main entry point for the AWS Lambda function using Mangum."""
+
+import json
+import os
+
+from aws_lambda_powertools import Logger
+from dotenv import load_dotenv
+from mangum import Mangum
+
+load_dotenv()
+
+from v1.server import mcp
+
+# Set the log level based on the DEBUG environment variable
+DEBUG = json.loads(os.environ.get("DEBUG", "false").lower())
+if DEBUG:
+    os.environ["POWERTOOLS_LOG_LEVEL"] = "DEBUG"
+
+# Initialize the logger
+logger = Logger()
+
+
+@logger.inject_lambda_context(log_event=DEBUG, clear_state=True)
+def lambda_handler(event, context):
+    """Lambda handler for the AWS Lambda function."""
+    app = mcp.http_app(stateless_http=True)
+
+    return Mangum(app, lifespan="on")(event, context)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/mcp-server32/mcp-server32/src/mlservice/db.py
+++ b/mcp-server32/mcp-server32/src/mlservice/db.py
@@ -1,0 +1,161 @@
+"""PostgreSQL Database Utilities"""
+
+import json
+import os
+import re
+from typing import Annotated, Self
+
+import pg8000
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.utilities import parameters
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = Logger()
+
+MUTATING_KEYWORDS = {
+    # DML
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "MERGE",
+    "TRUNCATE",
+    # DDL
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "RENAME",
+    # Permissions
+    "GRANT",
+    "REVOKE",
+    # Metadata changes
+    "COMMENT ON",
+    "SECURITY LABEL",
+    # Extensions and functions
+    "CREATE EXTENSION",
+    "CREATE FUNCTION",
+    "INSTALL",
+    # Storage-level
+    "CLUSTER",
+    "REINDEX",
+    "VACUUM",
+    "ANALYZE",
+}
+
+# Compile regex pattern
+MUTATING_PATTERN = re.compile(
+    r"(?i)\b(" + "|".join(re.escape(k) for k in MUTATING_KEYWORDS) + r")\b"
+)
+
+SUSPICIOUS_PATTERNS = [
+    r"(?i)\bor\b\s+\d+\s*=\s*\d+",  # numeric tautology e.g. OR 1=1
+    r"(?i)\bor\b\s*'[^']+'\s*=\s*'[^']+'",  # string tautology e.g. OR '1'='1'
+    r"(?i)\bdrop\b",  # DROP statement
+    r"(?i)\btruncate\b",  # TRUNCATE
+    r"(?i)\bgrant\b|\brevoke\b",  # GRANT or REVOKE
+    r"(?i)\bsleep\s*\(",  # delay-based probes
+    r"(?i)\bpg_sleep\s*\(",
+    r"(?i)\bload_file\s*\(",
+    r"(?i)\binto\s+outfile\b",
+]
+
+
+class Settings(BaseSettings):
+    """Settings for PostgreSQL connection."""
+
+    model_config = SettingsConfigDict(
+        env_file_encoding="utf-8",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    read_only_connection: Annotated[
+        bool,
+        Field(description="Use read-only connection for the database"),
+    ] = True
+    debug: Annotated[bool, Field(description="Enable debug mode")] = False
+
+    secret_id: Annotated[str | None, Field(description="Secret ID")] = None
+
+    pg_host: Annotated[str, Field(description="Host")]
+    pg_port: Annotated[int, Field(description="Port", default=5432)] = 5432
+    pg_password: Annotated[str, Field(description="Password")]
+    pg_user: Annotated[str, Field(description="User")]
+    pg_dbname: Annotated[str, Field(description="Database name")]
+
+    @model_validator(mode="before")
+    def evaluate(self: dict) -> dict:
+        """Get information from secrets manager if secret_id is set."""
+        if self.get("secret_id"):
+            cnxn_details: dict = parameters.get_secret(
+                self["secret_id"], transform="json"
+            )
+            try:
+                self["pg_host"] = str(cnxn_details["host"])
+                self["pg_port"] = int(cnxn_details.get("port", 5432))
+                self["pg_password"] = str(cnxn_details["password"])
+                user_name_attribute = (
+                    "username" if "username" in cnxn_details else "user"
+                )
+                self["pg_user"] = str(cnxn_details[user_name_attribute])
+                self["pg_dbname"] = str(cnxn_details["dbname"])
+            except KeyError as key_error:
+                logger.error('Parameter "%s" is missing.', key_error.args[0])
+                raise key_error
+
+        return self
+
+
+def get_cnxn(settings: Settings) -> pg8000.Connection:
+    """Get a PostgreSQL connection object.
+    This function creates a connection to a PostgreSQL database using the provided
+    connection details.
+    Args:
+        settings (Settings): Settings object containing PostgreSQL connection details.
+
+    Returns:
+        pg8000.Connection: PostgreSQL Connection object
+    """
+    logger.info(settings)
+
+    config = {
+        "host": settings.pg_host,
+        "port": settings.pg_port,
+        "user": settings.pg_user,
+        "password": settings.pg_password,
+        "database": settings.pg_dbname,
+        "ssl_context": True,
+    }
+
+    return pg8000.connect(**config)
+
+
+def detect_mutating_keywords(sql_text: str) -> list[str]:
+    """Return a list of mutating keywords found in the SQL (excluding comments)."""
+    matches = MUTATING_PATTERN.findall(sql_text)
+    return list(
+        {m.upper() for m in matches}
+    )  # Deduplicated and normalized to uppercase
+
+
+def check_sql_injection_risk(sql: str) -> list[dict]:
+    """Check for potential SQL injection risks in sql query.
+
+    Args:
+        sql: query string
+
+    Returns:
+        dictionaries containing detected security issue
+    """
+    issues = []
+    for pattern in SUSPICIOUS_PATTERNS:
+        if re.search(pattern, sql):
+            issues.append(
+                {
+                    "type": "sql",
+                    "message": f"Suspicious pattern in query: {sql}",
+                    "severity": "high",
+                }
+            )
+            break
+    return issues

--- a/mcp-server32/mcp-server32/src/tests/test_db.py
+++ b/mcp-server32/mcp-server32/src/tests/test_db.py
@@ -1,0 +1,455 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pg8000
+import pytest
+from mlservice.db import (
+    MUTATING_KEYWORDS,
+    SUSPICIOUS_PATTERNS,
+    Settings,
+    check_sql_injection_risk,
+    detect_mutating_keywords,
+    get_cnxn,
+)
+
+
+class TestSettings:
+    """Test cases for Settings class."""
+
+    @patch("aws_lambda_powertools.utilities.parameters.get_secret")
+    @patch.dict(os.environ, {"SECRET_ID": "test-secret"})
+    def test_settings_with_secret_id_username(self, mock_get_secret):
+        """Test Settings with AWS Secrets Manager using 'username' key."""
+        mock_secret = {
+            "host": "test-host",
+            "port": 5432,
+            "username": "test-user",
+            "password": "test-password",
+            "dbname": "test-db",
+        }
+        mock_get_secret.return_value = mock_secret
+
+        # When secret_id is provided in environment, Settings() should work
+        settings = Settings()  # type: ignore
+
+        assert settings.pg_host == "test-host"
+        assert settings.pg_port == 5432
+        assert settings.pg_user == "test-user"
+        assert settings.pg_password == "test-password"
+        assert settings.pg_dbname == "test-db"
+        mock_get_secret.assert_called_once_with("test-secret", transform="json")
+
+    @patch("aws_lambda_powertools.utilities.parameters.get_secret")
+    @patch.dict(os.environ, {"SECRET_ID": "test-secret"})
+    def test_settings_with_secret_id_user(self, mock_get_secret):
+        """Test Settings with AWS Secrets Manager using 'user' key."""
+        mock_secret = {
+            "host": "test-host",
+            "user": "test-user",
+            "password": "test-password",
+            "dbname": "test-db",
+        }
+        mock_get_secret.return_value = mock_secret
+
+        settings = Settings()  # type: ignore
+
+        assert settings.pg_host == "test-host"
+        assert settings.pg_port == 5432  # Default port
+        assert settings.pg_user == "test-user"
+        assert settings.pg_password == "test-password"
+        assert settings.pg_dbname == "test-db"
+
+    @patch("aws_lambda_powertools.utilities.parameters.get_secret")
+    @patch.dict(os.environ, {"SECRET_ID": "test-secret"})
+    def test_settings_missing_host_key(self, mock_get_secret):
+        """Test error when required key is missing from secret."""
+        mock_secret = {
+            "username": "test-user",
+            "password": "test-password",
+            "dbname": "test-db",
+        }
+        mock_get_secret.return_value = mock_secret
+
+        with pytest.raises(KeyError, match="host"):
+            Settings()  # type: ignore
+
+    @patch.dict(
+        os.environ,
+        {
+            "PG_HOST": "env-host",
+            "PG_PORT": "3306",
+            "PG_USER": "env-user",
+            "PG_PASSWORD": "env-password",
+            "PG_DBNAME": "env-db",
+        },
+        clear=True,
+    )
+    def test_settings_from_env_variables(self):
+        """Test Settings from environment variables."""
+        settings = Settings()  # type: ignore
+
+        assert settings.pg_host == "env-host"
+        assert settings.pg_port == 3306
+        assert settings.pg_user == "env-user"
+        assert settings.pg_password == "env-password"
+        assert settings.pg_dbname == "env-db"
+
+    @patch.dict(
+        os.environ,
+        {
+            "PG_HOST": "env-host",
+            "PG_USER": "env-user",
+            "PG_PASSWORD": "env-password",
+            "PG_DBNAME": "env-db",
+        },
+        clear=True,
+    )
+    def test_settings_from_env_variables_default_port(self):
+        """Test Settings from environment variables with default port."""
+        settings = Settings()  # type: ignore
+
+        assert settings.pg_host == "env-host"
+        assert settings.pg_port == 5432  # Default port when PG_PORT not set
+        assert settings.pg_user == "env-user"
+        assert settings.pg_password == "env-password"
+        assert settings.pg_dbname == "env-db"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_settings_no_connection_details(self):
+        """Test Settings when no connection details are provided."""
+        # Without secret_id or env vars, Settings should raise validation error
+        # since required fields are missing
+        with pytest.raises(ValueError):
+            Settings()  # type: ignore
+
+    def test_settings_default_values(self):
+        """Test Settings default values for new fields."""
+        settings = Settings(
+            pg_host="test-host",
+            pg_user="test-user",
+            pg_password="test-password",
+            pg_dbname="test-db",
+        )
+
+        # Test default values
+        assert settings.read_only_connection is True
+        assert settings.debug is False
+        assert settings.pg_port == 5432
+        assert settings.secret_id is None
+
+    def test_settings_custom_values(self):
+        """Test Settings with custom values."""
+        settings = Settings(
+            pg_host="test-host",
+            pg_user="test-user",
+            pg_password="test-password",
+            pg_dbname="test-db",
+            read_only_connection=False,
+            debug=True,
+            pg_port=3306,
+        )
+
+        assert settings.read_only_connection is False
+        assert settings.debug is True
+        assert settings.pg_port == 3306
+
+
+class TestGetCnxn:
+    """Test cases for get_cnxn function."""
+
+    @patch("mlservice.db.pg8000.connect")
+    def test_get_cnxn_success(self, mock_connect):
+        """Test successful database connection."""
+        mock_connection = MagicMock()
+        mock_connect.return_value = mock_connection
+
+        settings = Settings(
+            pg_host="test-host",
+            pg_port=5432,
+            pg_user="test-user",
+            pg_password="test-password",
+            pg_dbname="test-db",
+        )
+
+        result = get_cnxn(settings)
+
+        assert result == mock_connection
+        mock_connect.assert_called_once_with(
+            host="test-host",
+            port=5432,
+            user="test-user",
+            password="test-password",
+            database="test-db",
+            ssl_context=True,
+        )
+
+    @patch("mlservice.db.pg8000.connect")
+    def test_get_cnxn_connection_error(self, mock_connect):
+        """Test database connection error."""
+        mock_connect.side_effect = pg8000.Error("Connection failed")
+
+        settings = Settings(
+            pg_host="test-host",
+            pg_port=5432,
+            pg_user="test-user",
+            pg_password="test-password",
+            pg_dbname="test-db",
+        )
+
+        with pytest.raises(pg8000.Error, match="Connection failed"):
+            get_cnxn(settings)
+
+
+class TestDetectMutatingKeywords:
+    """Test cases for detect_mutating_keywords function."""
+
+    def test_detect_mutating_keywords_single_keyword(self):
+        """Test detection of single mutating keyword."""
+        sql = "SELECT * FROM users WHERE id = 1; INSERT INTO logs VALUES (1);"
+        result = detect_mutating_keywords(sql)
+        assert "INSERT" in result
+
+    def test_detect_mutating_keywords_multiple_keywords(self):
+        """Test detection of multiple mutating keywords."""
+        sql = "INSERT INTO table1 VALUES (1); UPDATE table2 SET col = 'value'; DELETE FROM table3;"
+        result = detect_mutating_keywords(sql)
+        assert "INSERT" in result
+        assert "UPDATE" in result
+        assert "DELETE" in result
+
+    def test_detect_mutating_keywords_case_insensitive(self):
+        """Test case insensitive detection."""
+        sql = (
+            "insert into table values (1); UPDATE table set col = 1; Delete from table;"
+        )
+        result = detect_mutating_keywords(sql)
+        assert "INSERT" in result
+        assert "UPDATE" in result
+        assert "DELETE" in result
+
+    def test_detect_mutating_keywords_no_keywords(self):
+        """Test SQL with no mutating keywords."""
+        sql = "SELECT * FROM users WHERE status = 'active';"
+        result = detect_mutating_keywords(sql)
+        assert result == []
+
+    def test_detect_mutating_keywords_deduplication(self):
+        """Test deduplication of repeated keywords."""
+        sql = "INSERT INTO table1 VALUES (1); INSERT INTO table2 VALUES (2);"
+        result = detect_mutating_keywords(sql)
+        assert set(result) == set(["INSERT"])
+
+    def test_detect_mutating_keywords_all_keywords(self):
+        """Test detection of various keyword types."""
+        test_cases = [
+            ("CREATE TABLE test (id INT);", ["CREATE"]),
+            ("DROP TABLE test;", ["DROP"]),
+            ("ALTER TABLE test ADD COLUMN name VARCHAR(50);", ["ALTER"]),
+            ("GRANT SELECT ON table TO user;", ["GRANT"]),
+            ("REVOKE SELECT ON table FROM user;", ["REVOKE"]),
+            ("TRUNCATE TABLE test;", ["TRUNCATE"]),
+            ("MERGE INTO target USING source ON condition;", ["MERGE"]),
+            ("RENAME TABLE old TO new;", ["RENAME"]),
+            ("CLUSTER table USING index;", ["CLUSTER"]),
+            ("REINDEX INDEX test_idx;", ["REINDEX"]),
+            ("VACUUM table;", ["VACUUM"]),
+            ("ANALYZE table;", ["ANALYZE"]),
+        ]
+
+        for sql, expected in test_cases:
+            result = detect_mutating_keywords(sql)
+            assert all(keyword in result for keyword in expected), (
+                f"Failed for SQL: {sql}"
+            )
+
+    def test_detect_mutating_keywords_word_boundaries(self):
+        """Test that keywords are detected only as whole words."""
+        sql = "SELECT * FROM table_insert WHERE column_update = 'delete_value';"
+        result = detect_mutating_keywords(sql)
+        assert result == []  # Should not detect keywords within other words
+
+
+class TestCheckSqlInjectionRisk:
+    """Test cases for check_sql_injection_risk function."""
+
+    def test_check_sql_injection_numeric_tautology(self):
+        """Test detection of numeric tautology SQL injection."""
+        sql = "SELECT * FROM users WHERE id = 1 OR 1=1"
+        result = check_sql_injection_risk(sql)
+        assert len(result) == 1
+        assert result[0]["type"] == "sql"
+        assert result[0]["severity"] == "high"
+        assert "Suspicious pattern" in result[0]["message"]
+
+    def test_check_sql_injection_string_tautology(self):
+        """Test detection of string tautology SQL injection."""
+        sql = "SELECT * FROM users WHERE name = 'admin' OR 'a'='a'"
+        result = check_sql_injection_risk(sql)
+        assert len(result) == 1
+        assert result[0]["type"] == "sql"
+        assert result[0]["severity"] == "high"
+
+    def test_check_sql_injection_drop_statement(self):
+        """Test detection of DROP statement."""
+        sql = "SELECT * FROM users; DROP TABLE users;"
+        result = check_sql_injection_risk(sql)
+        assert len(result) == 1
+        assert result[0]["severity"] == "high"
+
+    def test_check_sql_injection_truncate_statement(self):
+        """Test detection of TRUNCATE statement."""
+        sql = "SELECT * FROM users; TRUNCATE TABLE logs;"
+        result = check_sql_injection_risk(sql)
+        assert len(result) == 1
+
+    def test_check_sql_injection_grant_revoke(self):
+        """Test detection of GRANT/REVOKE statements."""
+        test_cases = [
+            "SELECT * FROM users; GRANT ALL ON *.* TO 'user'@'%';",
+            "SELECT * FROM users; REVOKE ALL ON *.* FROM 'user'@'%';",
+        ]
+        for sql in test_cases:
+            result = check_sql_injection_risk(sql)
+            assert len(result) == 1
+
+    def test_check_sql_injection_sleep_functions(self):
+        """Test detection of sleep functions."""
+        test_cases = [
+            "SELECT * FROM users WHERE id = 1 AND SLEEP(5)",
+            "SELECT * FROM users WHERE id = 1 AND PG_SLEEP(5)",
+        ]
+        for sql in test_cases:
+            result = check_sql_injection_risk(sql)
+            assert len(result) == 1
+
+    def test_check_sql_injection_file_operations(self):
+        """Test detection of file operation functions."""
+        test_cases = [
+            "SELECT * FROM users UNION SELECT LOAD_FILE('/etc/passwd')",
+            "SELECT * FROM users INTO OUTFILE '/tmp/users.txt'",
+        ]
+        for sql in test_cases:
+            result = check_sql_injection_risk(sql)
+            assert len(result) == 1
+
+    def test_check_sql_injection_case_insensitive(self):
+        """Test case insensitive detection."""
+        sql = "SELECT * FROM users WHERE id = 1 or 1=1"
+        result = check_sql_injection_risk(sql)
+        assert len(result) == 1
+
+    def test_check_sql_injection_clean_sql(self):
+        """Test clean SQL with no injection risks."""
+        sql = "SELECT id, name, email FROM users WHERE status = 'active' AND created_date > '2023-01-01'"
+        result = check_sql_injection_risk(sql)
+        assert result == []
+
+    def test_check_sql_injection_stops_at_first_match(self):
+        """Test that function stops at first suspicious pattern found."""
+        sql = "SELECT * FROM users WHERE id = 1 OR 1=1; DROP TABLE users;"
+        result = check_sql_injection_risk(sql)
+        assert (
+            len(result) == 1
+        )  # Should only return one issue despite multiple patterns
+
+    def test_check_sql_injection_empty_sql(self):
+        """Test with empty SQL string."""
+        result = check_sql_injection_risk("")
+        assert result == []
+
+    def test_check_sql_injection_whitespace_variations(self):
+        """Test detection with various whitespace patterns."""
+        test_cases = [
+            "SELECT * FROM users WHERE id = 1 OR  1 = 1",
+            "SELECT * FROM users WHERE id = 1 OR\t1\t=\t1",
+            "SELECT * FROM users WHERE id = 1 OR\n1\n=\n1",
+        ]
+        for sql in test_cases:
+            result = check_sql_injection_risk(sql)
+            assert len(result) == 1, f"Failed to detect injection in: {sql}"
+
+
+class TestConstants:
+    """Test cases for module constants."""
+
+    def test_mutating_keywords_complete(self):
+        """Test that MUTATING_KEYWORDS contains expected keywords."""
+        expected_keywords = {
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+            "MERGE",
+            "TRUNCATE",
+            "CREATE",
+            "DROP",
+            "ALTER",
+            "RENAME",
+            "GRANT",
+            "REVOKE",
+            "COMMENT ON",
+            "SECURITY LABEL",
+            "CREATE EXTENSION",
+            "CREATE FUNCTION",
+            "INSTALL",
+            "CLUSTER",
+            "REINDEX",
+            "VACUUM",
+            "ANALYZE",
+        }
+        assert expected_keywords.issubset(MUTATING_KEYWORDS)
+
+    def test_suspicious_patterns_count(self):
+        """Test that we have the expected number of suspicious patterns."""
+        assert len(SUSPICIOUS_PATTERNS) == 9
+
+    def test_suspicious_patterns_are_strings(self):
+        """Test that all suspicious patterns are strings."""
+        assert all(isinstance(pattern, str) for pattern in SUSPICIOUS_PATTERNS)
+
+
+class TestIntegration:
+    """Integration tests combining multiple functions."""
+
+    @patch("aws_lambda_powertools.utilities.parameters.get_secret")
+    @patch("mlservice.db.pg8000.connect")
+    @patch.dict(os.environ, {"SECRET_ID": "test-secret"})
+    def test_full_connection_flow_with_secret(self, mock_connect, mock_get_secret):
+        """Test complete flow from Settings to establishing connection."""
+        mock_secret = {
+            "host": "test-host",
+            "port": 5432,
+            "username": "test-user",
+            "password": "test-password",
+            "dbname": "test-db",
+        }
+        mock_get_secret.return_value = mock_secret
+        mock_connection = MagicMock()
+        mock_connect.return_value = mock_connection
+
+        # Create settings (will load from secret)
+        settings = Settings()  # type: ignore
+
+        # Establish connection
+        connection = get_cnxn(settings)
+
+        assert connection == mock_connection
+        mock_connect.assert_called_once_with(
+            host="test-host",
+            port=5432,
+            user="test-user",
+            password="test-password",
+            database="test-db",
+            ssl_context=True,
+        )
+
+    def test_sql_security_checks_comprehensive(self):
+        """Test comprehensive SQL security checking."""
+        malicious_sql = "SELECT * FROM users WHERE id = 1 OR 1=1; DROP TABLE users;"
+
+        # Check for injection risks
+        injection_risks = check_sql_injection_risk(malicious_sql)
+        assert len(injection_risks) == 1
+
+        # Check for mutating keywords
+        mutating_keywords = detect_mutating_keywords(malicious_sql)
+        assert "DROP" in mutating_keywords

--- a/mcp-server32/mcp-server32/src/v1/server.py
+++ b/mcp-server32/mcp-server32/src/v1/server.py
@@ -1,0 +1,264 @@
+"""PostgreSQL MCP Server implementation."""
+
+import json
+import os
+from typing import Annotated, Any, Dict
+
+from aws_lambda_powertools import Logger
+from fastmcp import FastMCP
+from mlservice.db import (
+    Settings,
+    check_sql_injection_risk,
+    detect_mutating_keywords,
+    get_cnxn,
+)
+from pydantic import Field
+
+settings = Settings()
+if settings.debug:
+    os.environ["LOG_LEVEL"] = "DEBUG"
+
+logger = Logger()
+
+
+mcp = FastMCP("Postgresql MCP Server")
+
+#####################################
+### Resource Definitions
+#####################################
+
+
+@mcp.resource("postgresql://{table_name}/data")
+def get_table_data(
+    table_name: Annotated[str, Field(description="Name of the table")],
+    schema_name: Annotated[str, Field(description="Schema name")] = "public",
+    max_rows: Annotated[
+        int, Field(description="Maximum number of rows to return")
+    ] = 100,
+) -> str:
+    """Get data for a table."""
+    query = f"SELECT * FROM {schema_name}.{table_name} LIMIT {max_rows}"
+
+    return execute_sql.fn(query=query)
+
+
+#####################################
+### Tool Definitions
+#####################################
+
+
+@mcp.tool
+def get_tables(
+    schema_name: Annotated[str, Field(description="Schema name")] = "public",
+) -> list[dict]:
+    """List PostgreSQL tables and views with their descriptions."""
+
+    with get_cnxn(settings) as cnxn:
+        cursor = cnxn.cursor()
+        try:
+            # Query to get user tables and views with descriptions from PostgreSQL
+            cursor.execute(
+                """
+                SELECT 
+                    t.table_name,
+                    t.table_type,
+                    obj_description(pgc.oid) AS table_description
+                FROM information_schema.tables t
+                LEFT JOIN pg_catalog.pg_class pgc ON pgc.relname = t.table_name
+                LEFT JOIN pg_catalog.pg_namespace pgn ON pgn.oid = pgc.relnamespace 
+                    AND pgn.nspname = t.table_schema
+                WHERE t.table_schema = %s
+                    AND t.table_type IN ('BASE TABLE','VIEW') AND obj_description(pgc.oid) is not null
+
+                UNION ALL
+
+                SELECT 
+                    pgc.relname AS table_name,
+                    'MATERIALIZED VIEW' AS table_type,
+                    obj_description(pgc.oid) AS table_description
+                FROM pg_catalog.pg_class pgc
+                JOIN pg_catalog.pg_namespace pgn ON pgn.oid = pgc.relnamespace
+                WHERE pgn.nspname = %s
+                    AND pgc.relkind = 'm' AND obj_description(pgc.oid) is not null
+
+                ORDER BY table_name
+                """,
+                (schema_name, schema_name),
+            )
+            tables = cursor.fetchall()
+            logger.info(f"Found tables and (materialized) views: {tables}")
+
+            tables_output = []
+            for table in tables:
+                table_info = {
+                    "name": table[0],
+                    "type": table[1],  # 'VIEW' or 'MATERIALIZED VIEW'
+                    "description": table[2] if table[2] else None,
+                }
+                tables_output.append(table_info)
+
+            return tables_output
+        except Exception as e:
+            logger.error(f"Failed to list resources: {str(e)}")
+            return []
+        finally:
+            cursor.close()
+
+
+@mcp.tool
+def get_table_schemas(
+    tables: Annotated[list[str], Field(description="Names of the tables")],
+    schema_name: Annotated[str, Field(description="Schema name")] = "public",
+) -> list[Dict[str, Any]]:
+    """Get schema information for tables including column details and foreign key relationships."""
+
+    query = """
+        WITH all_columns AS (
+            SELECT 
+                a.attname AS column_name,
+                pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+                CASE 
+                    WHEN a.atttypmod > 0 AND t.typname IN ('varchar', 'char', 'bpchar') 
+                    THEN a.atttypmod - 4
+                    ELSE NULL
+                END AS character_maximum_length,
+                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+                pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) AS column_default,
+                c.relname AS table_name,
+                n.nspname AS table_schema,
+                a.attnum AS ordinal_position,
+                c.oid AS table_oid
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+            JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
+            LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = c.oid AND ad.adnum = a.attnum
+            WHERE c.relkind IN ('r', 'v', 'm')  -- tables, views, materialized views
+            AND n.nspname = %s
+            AND c.relname = ANY(%s)
+            AND a.attnum > 0
+            AND NOT a.attisdropped
+        )
+        SELECT
+            ac.column_name,
+            ac.data_type,
+            ac.character_maximum_length,
+            ac.is_nullable,
+            ac.column_default,
+            col_desc.description AS column_description,
+            tbl_desc.description AS table_description,
+            ac.table_name,
+            tc.constraint_name AS fk_constraint_name,
+            ccu.table_schema AS fk_referenced_schema,
+            ccu.table_name AS fk_referenced_table,
+            ccu.column_name AS fk_referenced_column
+        FROM all_columns ac
+        -- Column descriptions
+        LEFT JOIN pg_catalog.pg_description col_desc ON col_desc.objoid = ac.table_oid
+            AND col_desc.objsubid = ac.ordinal_position
+        -- Table descriptions  
+        LEFT JOIN pg_catalog.pg_description tbl_desc ON tbl_desc.objoid = ac.table_oid
+            AND tbl_desc.objsubid = 0
+        -- Foreign key information (simplified)
+        LEFT JOIN information_schema.key_column_usage kcu ON kcu.table_schema = ac.table_schema
+            AND kcu.table_name = ac.table_name
+            AND kcu.column_name = ac.column_name
+        LEFT JOIN information_schema.table_constraints tc ON tc.constraint_name = kcu.constraint_name
+            AND tc.constraint_type = 'FOREIGN KEY'
+        LEFT JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name
+        ORDER BY ac.table_name, ac.ordinal_position;
+        """
+    with get_cnxn(settings) as cnxn:
+        cursor = cnxn.cursor()
+        try:
+            cursor.execute(query, (schema_name, tables))
+            columns = cursor.fetchall()
+            # Group columns by table name
+            tables_schemas = {}
+            for col in columns:
+                table_name = col[7]  # table_name is now the 8th column (index 7)
+
+                if table_name not in tables_schemas:
+                    tables_schemas[table_name] = {
+                        "name": table_name,
+                        "schema": schema_name,
+                        "description": col[6] if col[6] else None,  # table description
+                        "columns": [],
+                    }
+
+                # Build foreign key info if it exists
+                foreign_key = None
+                if col[8]:  # fk_constraint_name exists
+                    foreign_key = {
+                        "referenced_schema": col[9],
+                        "referenced_table": col[10],
+                        "referenced_column": col[11],
+                    }
+
+                tables_schemas[table_name]["columns"].append(
+                    {
+                        "name": col[0],
+                        "type": col[1],
+                        "max_length": col[2],
+                        "nullable": col[3],
+                        "default": col[4],
+                        "description": col[5] if col[5] else None,
+                        "foreign_key": foreign_key,
+                    }
+                )
+
+            return list(tables_schemas.values())
+        except Exception as e:
+            logger.error(f"Error getting table schemas: {str(e)}")
+            return []
+        finally:
+            cursor.close()
+
+
+@mcp.tool()
+def execute_sql(
+    query: Annotated[str, Field(description="SQL query to execute")],
+) -> str:
+    """Execute a SQL query and return the result."""
+
+    if settings.read_only_connection:
+        matches = detect_mutating_keywords(query)
+        if matches:
+            logger.info(
+                f"Query is rejected because current setting only allows readonly query. \
+                    Detected keywords: {matches}, SQL query: {query}"
+            )
+            return "Error: Your MCP tool only allows readonly query. \
+                If you want to write, change the MCP configuration"
+
+    issues = check_sql_injection_risk(query)
+    if issues:
+        logger.info(
+            f"query is rejected because it contains risky SQL pattern, \
+                SQL query: {query}, reasons: {issues}"
+        )
+        return f"Query parameter contains suspicious pattern with following issues: {issues}"
+
+    with get_cnxn(settings) as cnxn:
+        cursor = cnxn.cursor()
+        try:
+            logger.info(f"Executing SQL query: {query}")
+            cursor.execute(query)
+            # Regular SELECT queries
+            if query.strip().upper().startswith(("SELECT", "WITH")):
+                columns = [desc[0] for desc in cursor.description]
+                rows = cursor.fetchall()
+                result = [",".join(map(str, row)) for row in rows]
+                return "\n".join([",".join(columns)] + result)
+
+            # Non-SELECT queries
+            cnxn.commit()
+            affected_rows = cursor.rowcount
+            return f"Query executed successfully. Rows affected: {affected_rows}"
+
+        except Exception as e:
+            logger.error(f"Error executing SQL '{query}': {e}")
+            return f"Error executing query: {str(e)}"
+
+        finally:
+            cursor.close()

--- a/mcp-server32/mcp-server32/terraform/main.tf
+++ b/mcp-server32/mcp-server32/terraform/main.tf
@@ -1,0 +1,110 @@
+locals {
+  # Define the prefix for the resources
+  prefix = "my-pgsql-mcp"
+
+  # Networking
+  subnet_ids_private = ["subnet-***", "subnet-***"] # Replace with your actual private subnet IDs
+  vpc_id = "vpc-***" # Replace with your actual VPC ID
+
+  # AWS Secrets Manager
+  rds_secret_arn = "arn:aws:secretsmanager:***" # Replace with your actual RDS secret ARN. If not used, remove references below
+
+  # Route 53 configuration
+  r53_public_hosted_zone = "YOUR_ACCOUNT_ID.cloud.bayer.com" # Replace with your actual Route 53 public hosted zone ID
+  subdomain = "mcp" # Replace with your desired subdomain
+}
+
+# Check if newer version of the module is available
+module "mlservice_api_mcp" {
+  source = "github.com/bayer-int/ph-ds-ml-serverless-api-mcp?ref=v2.1.0"
+
+  # Required basic configuration
+  prefix      = local.prefix
+  environment = "dev"
+
+  # Route configuration for Streamable HTTP transport endpoint
+  # Two HTTP methods are supported by the streamable HTTP transport: GET and POST
+  routes = {
+    "GET /mcp" = {
+      authorize = false
+    }
+    "POST /mcp" = {
+      authorize = false
+    }
+  }
+
+  # Required API Lambda configuration - using the example MCP server code
+  lambda_api = {
+    source_path = [
+      "../src/main.py",
+      {
+        path          = "../src/v1",
+        prefix_in_zip = "v1"
+      },
+      {
+        path          = "../src/mlservice",
+        prefix_in_zip = "mlservice"
+      }
+    ] # Path to exemplary MCP code
+
+    vpc = {
+      subnet_ids_private = local.subnet_ids_private # Private subnets for the Lambda function
+      security_group_ids = [aws_security_group.this.id] # Security group for the Lambda function
+    }
+
+    environment_variables = {
+      # Required environment variables for the Lambda function
+      SECRET_ID = local.rds_secret_arn # ARN of the RDS secret in AWS Secrets Manager
+    }
+
+    # Optional, if using AWS Secrets Manager for RDS credentials 
+    policy_statements = {
+      s3_access = {
+        effect    = "Allow"
+        actions   = ["secretsmanager:GetSecretValue"]
+        resources = [local.rds_secret_arn] 
+      }
+    }
+
+    layers = {
+      # AWS managed layer that includes pg8000. Alternatively, you can use a custom layer with pg8000 installed.
+      custom = ["arn:aws:lambda:eu-central-1:336392948345:layer:AWSSDKPandas-Python313-Arm64:3"] # for pg8000
+    }
+  }
+
+  # Required API Gateway configuration
+  api_gateway = {
+    custom_domain = {
+      r53_public_hosted_zone = local.r53_public_hosted_zone
+      subdomain              = local.subdomain
+    }
+  }
+}
+
+resource "aws_security_group" "this" {
+  # Set the security group name using a combination of the prefix, use case, and user profile
+  name = "${local.prefix}-lambda-sg"
+
+  # Set the description for the security group
+  description = "${local.prefix}-lambda"
+
+  # Set the VPC ID for the security group
+  vpc_id = local.vpc_id
+
+  # Define egress rule to allow all outbound traffic to postgres DBs
+  dynamic "egress" {
+    for_each = [443, 5432]
+    content {
+      from_port   = egress.value
+      to_port     = egress.value
+      protocol    = "TCP"
+      cidr_blocks = ["0.0.0.0/0"] # Adjust outbound CIDR blocks as needed, e.g., to VPC CIDR of your RDS instance
+      description = "Allow outbound traffic."
+    }
+  }
+
+  # Define tags for the security group
+  tags = {
+    Name = "${local.prefix}-lambda-sg"
+  }
+}


### PR DESCRIPTION
## Add MCP Server: service-mcp

This PR adds the production-ready **postgres** MCP server from [bayer-int/mcp-servers](https://github.com/bayer-int/mcp-servers).

**Details:**
- **Server Type**: postgres MCP Server
- **Service Name**: service-mcp
- **Owner**: user:default/santosh5321

**What Was Added:**
- `mcp-server32/` - Complete MCP server implementation
- Production-ready FastMCP server
- AWS Lambda deployment ready

**Next Steps:**
1. Configure environment variables as needed
2. Start server: `cd mcp-server32 && uv run main.py`
3. Deploy to AWS using included Terraform configuration

Generated using Backstage template.

**Documentation:** [bayer-int/mcp-servers](https://github.com/bayer-int/mcp-servers)
